### PR TITLE
Fix solver context bug

### DIFF
--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -28,3 +28,23 @@ def test_solve_coo(rng, solver, n):
     x1 = solve_coo(m.data, (m.row, m.col), b, solver=_solver)
 
     assert_allclose(x0, x1)
+
+
+def test_solver_instances_are_independent(rng):
+    a = rng.random((5, 5))
+    b = rng.random((5, 5))
+
+    m1 = coo_matrix(a @ a.T)
+    m2 = coo_matrix(b @ b.T)
+
+    rhs1 = rng.random(5)
+    rhs2 = rng.random(5)
+
+    solver1 = get_solver("SuperLU")
+    solver2 = get_solver("SuperLU")
+
+    x1 = solve_coo(m1.data, (m1.row, m1.col), rhs1, solver=solver1)
+    _ = solve_coo(m2.data, (m2.row, m2.col), rhs2, solver=solver2)
+    y1 = solve_coo(m1.data, (m1.row, m1.col), rhs1, solver=solver1)
+
+    assert_allclose(x1, y1)

--- a/tofea/solvers.py
+++ b/tofea/solvers.py
@@ -18,10 +18,9 @@ class Solver(ABC):
 
 
 class SuperLU(Solver):
-    _ctx: dict = {}
-
     def __init__(self, **options):
-        self._ctx["splu"] = partial(splu, **options)
+        # store solver-specific context on the instance to avoid cross-talk
+        self._ctx: dict = {"splu": partial(splu, **options)}
 
     def factor(self, m: csc_matrix) -> None:
         self._ctx["factorization"] = self._ctx["splu"](m)


### PR DESCRIPTION
## Summary
- isolate SuperLU solver context per instance
- add regression test ensuring solver instances do not interfere

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68500617e1448332b396c7409106f55d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved solver reliability by ensuring that multiple solver instances operate independently without sharing internal state.

- **Tests**
  - Added a new test to verify that separate solver instances do not interfere with each other.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->