### PR TITLE
Update dependencies and CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.12.0
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,17 @@ readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
-requires-python = ">=3.10,<=3.12"
-dependencies = ["numpy", "scipy", "sympy", "autograd"]
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "numpy>=1.26",
+    "scipy>=1.11",
+    "sympy>=1.13",
+    "autograd>=1.8",
+]
 
 [project.optional-dependencies]
 tests = ["pytest", "pytest-cov"]


### PR DESCRIPTION
## Summary
- bump ruff-pre-commit hook
- support Python 3.12 and 3.13
- require newer package versions
- expand the CI matrix
- fix Python version constraint

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685647eed5d483328d44bb888e59e046