### PR TITLE
Fix docs build and add material theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ The package contains examples of topology optimization for 2D and 3D heat and co
 
 To run the examples, there are some additional dependencies for optimization and plotting, so install using `pip install tofea[examples]`.
 
+## Documentation
+
+The API reference is built with [MkDocs](https://www.mkdocs.org/) and
+[mkdocstrings](https://mkdocstrings.github.io/). Install the documentation
+extras and run `mkdocs serve` to preview the site locally:
+
+```bash
+pip install -e .[docs]
+mkdocs serve
+```
+
 ## Disclaimer
 
 The package is pretty bare-bones and waiting for a big refactor, which I have not gotten around to.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: tofea

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,11 @@
 site_name: TOFEA
 repo_url: https://github.com/mrbaozi/tofea
 docs_dir: docs
+theme:
+  name: material
+nav:
+  - Home: index.md
+  - Reference: reference.md
 plugins:
   - search
   - mkdocstrings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 tests = ["pytest", "pytest-cov"]
 examples = ["nlopt", "matplotlib"]
 all = ["tofea[tests,examples]"]
-docs = ["mkdocs", "mkdocstrings[python]"]
+docs = ["mkdocs", "mkdocstrings[python]", "mkdocs-material"]
 dev = ["tofea[all,docs]", "ruff", "mypy", "pre-commit"]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- generate API docs using mkdocstrings
- switch docs to the Material theme
- document how to build the docs locally

## Testing
- `mkdocs build -s`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566198a4c88332957d408b2ee2f2f0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new section to the README with instructions for generating and previewing API documentation.
  - Introduced an initial API reference page.
  - Updated site configuration to improve documentation navigation and appearance.
  - Enhanced documentation dependencies for improved theming support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->