### PR TITLE
Fix API docs generation

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,3 +1,7 @@
 # API Reference
 
 ::: tofea
+::: tofea.elements
+::: tofea.fea2d
+::: tofea.primitives
+::: tofea.solvers

--- a/tofea/__init__.py
+++ b/tofea/__init__.py
@@ -1,5 +1,16 @@
 """Light-weight, differentiable finite element analysis package."""
 
+from __future__ import annotations
+
+__all__ = [
+    "elements",
+    "fea2d",
+    "primitives",
+    "solvers",
+    "DEFAULT_SOLVER",
+    "__version__",
+]
+
 __version__ = "0.1.0"
 
 DEFAULT_SOLVER = "SuperLU"


### PR DESCRIPTION
## Summary
- expose submodules in `__all__`
- list each module in `reference.md`

## Testing
- `pytest -q`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_6856708297308332bbb0a71351778387