### PR TITLE
Improve documentation and enable doctest

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -46,7 +46,7 @@ jobs:
       run: mypy tofea
 
     - name: Test with pytest
-      run: pytest --cov tofea
+      run: pytest --doctest-modules --cov tofea
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ The package contains examples of topology optimization for 2D and 3D heat and co
 
 To run the examples, there are some additional dependencies for optimization and plotting, so install using `pip install tofea[examples]`.
 
+```bash
+python examples/compliance_2d.py
+```
+
+This will start an optimization run and display the design evolution in a
+window. The heat conduction example can be run in the same way.
+
 ## Documentation
 
 The API reference is built with [MkDocs](https://www.mkdocs.org/) and

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,13 @@
 # TOFEA Documentation
 
 Welcome to the TOFEA documentation. This site is generated with MkDocs and
-contains API reference material extracted from the source code.
+contains API reference material extracted from the source code. The examples in
+the repository show how to solve simple heat conduction and compliance problems
+using `autograd` for automatic differentiation.
+
+To build the documentation locally use:
+
+```bash
+pip install -e .[docs]
+mkdocs serve
+```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,5 +1,10 @@
 # API Reference
 
+This section contains the automatically generated API reference. Each module is
+documented with [`mkdocstrings`](https://mkdocstrings.github.io/) and the
+examples included in the docstrings are executed as doctests during continuous
+integration to ensure they remain correct.
+
 ::: tofea
 ::: tofea.elements
 ::: tofea.fea2d

--- a/examples/compliance_2d.py
+++ b/examples/compliance_2d.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Compliance optimization example using 2D finite elements."""
 
 import autograd.numpy as np
 import matplotlib.pyplot as plt

--- a/examples/heat_2d.py
+++ b/examples/heat_2d.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Heat conduction optimization example using 2D finite elements."""
 
 import autograd.numpy as np
 import matplotlib.pyplot as plt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,3 +10,7 @@ plugins:
   - search
   - mkdocstrings:
       default_handler: python
+      handlers:
+        python:
+          options:
+            docstring_style: numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,4 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]
+addopts = "--doctest-modules"

--- a/tofea/fea2d.py
+++ b/tofea/fea2d.py
@@ -16,7 +16,22 @@ from tofea.solvers import Solver, get_solver
 
 @dataclass
 class FEA2D(ABC):
-    """Abstract base class for 2D finite element models."""
+    """Abstract base class for 2D finite element models.
+
+    Parameters
+    ----------
+    fixed
+        Boolean mask indicating which degrees of freedom are fixed.
+    solver
+        Name of the backend solver to use.
+    dx, dy
+        Element dimensions in ``x`` and ``y`` direction.
+
+    Notes
+    -----
+    Subclasses must provide the element matrix and a mapping from element
+    degrees of freedom to system degrees of freedom.
+    """
 
     fixed: NDArray[np.bool_]
     solver: str = DEFAULT_SOLVER
@@ -116,7 +131,19 @@ class FEA2D(ABC):
 
 @dataclass
 class FEA2D_K(FEA2D):
-    """Finite element model for compliance problems."""
+    """Finite element model for compliance problems.
+
+    This model solves small deformation elasticity problems using bilinear
+    quadrilateral elements.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> fixed = np.zeros((2, 2, 2), dtype=bool)
+    >>> fem = FEA2D_K(fixed)
+    >>> fem.element.shape
+    (8, 8)
+    """
 
     dof_dim: int = 2
     e: float = 1.0
@@ -150,7 +177,16 @@ class FEA2D_K(FEA2D):
 
 @dataclass
 class FEA2D_T(FEA2D):
-    """Finite element model for heat conduction problems."""
+    """Finite element model for heat conduction problems.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> fixed = np.zeros((2, 2), dtype=bool)
+    >>> fem = FEA2D_T(fixed)
+    >>> fem.element.shape
+    (4, 4)
+    """
 
     dof_dim: int = 1
     k: float = 1.0

--- a/tofea/solvers.py
+++ b/tofea/solvers.py
@@ -42,7 +42,21 @@ class SuperLU(Solver):
 
 
 def get_solver(solver: str) -> Solver:
-    """Return a solver instance by name."""
+    """Return a solver instance by name.
+
+    Parameters
+    ----------
+    solver
+        Name of the solver implementation. Currently only ``"SuperLU"`` is
+        available.
+
+    Examples
+    --------
+    >>> from tofea.solvers import get_solver, Solver
+    >>> s = get_solver("SuperLU")
+    >>> isinstance(s, Solver)
+    True
+    """
     match solver:
         case "SuperLU":
             return SuperLU(


### PR DESCRIPTION
## Summary
- expand README examples section
- update docs index and reference
- configure mkdocstrings for numpy docstrings
- add short docstrings to example scripts
- improve `FEA2D` docs and add small doctest examples
- clarify `get_solver` documentation
- enable doctests in CI
- run tests with doctest support by default

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy tofea`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685689eebd248332aa3b7dbec7168817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded and clarified docstrings across multiple modules, including detailed parameter descriptions and usage examples.
  - Added introductory and explanatory text to the API reference and main documentation, including instructions for building documentation locally.
  - Enhanced the README with a concrete example command and explanation for running example scripts.
  - Added module-level docstrings to example scripts for improved clarity.
- **Chores**
  - Updated test configuration and continuous integration to include doctest execution.
  - Configured documentation tools to use the NumPy docstring style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->