### PR TITLE
Add efficient self-adjoint FE objective

### DIFF
--- a/examples/compliance_2d.py
+++ b/examples/compliance_2d.py
@@ -53,8 +53,7 @@ def main():
     @value_and_grad
     def objective(x):
         x = parametrization(x)
-        d = fem.displacement(x, load)
-        c = fem.compliance(x, d)
+        c = fem.compliance(x, load)
         return c
 
     @value_and_grad

--- a/tests/test_adjoint_paths.py
+++ b/tests/test_adjoint_paths.py
@@ -1,0 +1,44 @@
+import autograd.numpy as anp
+import numpy as np
+from autograd import value_and_grad
+from numpy.testing import assert_allclose
+
+from tofea.fea2d import FEA2D_K, FEA2D_T
+
+
+def test_self_adjoint_vs_generic_compliance():
+    fixed = np.zeros((3, 3, 2), dtype=bool)
+    fixed[0] = 1
+    fem = FEA2D_K(fixed)
+    x = np.full(fem.shape, 0.5)
+    load = np.zeros_like(fixed, dtype=float)
+    load[-1, -1, 1] = 1.0
+
+    def generic_obj(x_):
+        return anp.dot(fem.displacement(x_, load).ravel(), load.ravel())
+
+    val_gen, grad_gen = value_and_grad(generic_obj)(x)
+
+    val_sa, grad_sa = value_and_grad(lambda x_: fem.compliance(x_, load))(x)
+
+    assert_allclose(val_gen, val_sa)
+    assert_allclose(grad_gen, grad_sa)
+
+
+def test_self_adjoint_vs_generic_thermal_compliance():
+    fixed = np.zeros((3, 3), dtype=bool)
+    fixed[0, 0] = 1
+    fem = FEA2D_T(fixed)
+    x = np.full(fem.shape, 0.5)
+    load = np.zeros_like(fixed, dtype=float)
+    load[-1, -1] = 1.0
+
+    def generic_obj(x_):
+        return anp.dot(fem.temperature(x_, load).ravel(), load.ravel())
+
+    val_gen, grad_gen = value_and_grad(generic_obj)(x)
+
+    val_sa, grad_sa = value_and_grad(lambda x_: fem.thermal_compliance(x_, load))(x)
+
+    assert_allclose(val_gen, val_sa)
+    assert_allclose(grad_gen, grad_sa)

--- a/tests/test_fea2d.py
+++ b/tests/test_fea2d.py
@@ -59,11 +59,13 @@ class TestFEA2DK:
             order=1,
         )(b)
 
-    def test_compliance_grads(self, fea2d_k_instance, x_and_b, rng):
-        x, _ = x_and_b
-        d = rng.random(fea2d_k_instance.dofs.shape)
-        check_grads(lambda x_: fea2d_k_instance.compliance(x_, d), modes=["fwd", "rev"], order=1)(x)
-        check_grads(lambda d_: fea2d_k_instance.compliance(x, d_), modes=["fwd", "rev"], order=1)(d)
+    def test_compliance_grads(self, fea2d_k_instance, x_and_b):
+        x, b = x_and_b
+        check_grads(
+            lambda x_: fea2d_k_instance.compliance(x_, b),
+            modes=["rev"],
+            order=1,
+        )(x)
 
 
 class TestFEA2DT:
@@ -110,6 +112,14 @@ class TestFEA2DT:
             modes=["fwd", "rev"],
             order=1,
         )(b)
+
+    def test_thermal_compliance_grads(self, fea2d_t_instance, x_and_b):
+        x, b = x_and_b
+        check_grads(
+            lambda x_: fea2d_t_instance.thermal_compliance(x_, b),
+            modes=["rev"],
+            order=1,
+        )(x)
 
 
 def test_fea2d_k_solution_matches_spsolve():


### PR DESCRIPTION
## Summary
- create a primitive for self-adjoint compliance objectives
- implement `_self_adjoint_objective` in `FEA2D`
- expose fast compliance and thermal compliance APIs
- update docstrings and example usage
- add regression tests to compare generic vs. self-adjoint paths

## Testing
- `pytest tests/test_adjoint_paths.py::test_self_adjoint_vs_generic_compliance -q`
- `pytest tests/test_adjoint_paths.py::test_self_adjoint_vs_generic_thermal_compliance -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857256f9fd08332ac4b5fbd56b31ebc

<!-- greptile_comment -->

## Greptile Summary

Implements an optimized self-adjoint pathway for finite element analysis compliance objectives, significantly reducing computational overhead by eliminating redundant adjoint solves during gradient computation.

- Added new primitive `solve_and_compute_self_adjoint_objective` in `tofea/primitives.py` that combines solving and objective computation into a single step
- Introduced `_self_adjoint_objective` method in `tofea/fea2d.py` with new public APIs `compliance()` and `thermal_compliance()` for optimized calculations
- Simplified `examples/compliance_2d.py` to use the new streamlined `fem.compliance()` API instead of separate displacement and compliance calculations
- Added comprehensive regression tests in `tests/test_adjoint_paths.py` to verify mathematical equivalence between generic and self-adjoint approaches
- Updated `tests/test_fea2d.py` to focus on reverse mode differentiation and add thermal compliance gradient tests



<!-- /greptile_comment -->