### PR TITLE
Add BoundaryConditions helper module

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -8,5 +8,6 @@ integration to ensure they remain correct.
 ::: tofea
 ::: tofea.elements
 ::: tofea.fea2d
+::: tofea.boundary_conditions
 ::: tofea.primitives
 ::: tofea.solvers

--- a/examples/heat_2d.py
+++ b/examples/heat_2d.py
@@ -32,17 +32,16 @@ def main():
     volfrac = 0.5
     sigma = 1.0
     shape = (100, 100)
-    nelx, nely = shape
     cmin, cmax = 1e-4, 1
 
-    fixed = np.zeros((nelx + 1, nely + 1), dtype="?")
-    load = np.zeros_like(fixed)
+    bc = BoundaryConditions(shape)
+    bc.fix_edge("top")
+    bc.apply_uniform_load_on_edge("bottom", 1.0)
+    bc.apply_uniform_load_on_edge("left", 1.0)
+    bc.apply_uniform_load_on_edge("right", 1.0)
 
-    fixed[shape[0] // 2 - 5 : shape[0] // 2 + 5, -1] = 1
-    load[:, 0] = 1
-    load[(0, -1), :] = 1
-
-    fem = FEA2D_T(fixed)
+    load = bc.load
+    fem = FEA2D_T(bc.fixed)
     parametrization = simp_parametrization(shape, sigma, cmin, cmax)
     x0 = np.full(shape, volfrac)
 

--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -1,0 +1,70 @@
+import numpy as np
+import pytest
+
+from tofea.boundary_conditions import BoundaryConditions
+from tofea.fea2d import FEA2D_K, FEA2D_T
+
+
+def test_fix_edge_1d():
+    bc = BoundaryConditions((10, 10))
+    bc.fix_edge("left")
+    assert bc.fixed.shape == (11, 11)
+    assert np.all(bc.fixed[0])
+    assert not np.any(bc.fixed[1:])
+
+    bc = BoundaryConditions((10, 10))
+    bc.fix_edge("top")
+    assert np.all(bc.fixed[:, -1])
+
+
+def test_fix_edge_2d():
+    bc = BoundaryConditions((5, 5), dof_dim=2)
+    bc.fix_edge("bottom")
+    assert bc.fixed.shape == (6, 6, 2)
+    assert np.all(bc.fixed[:, 0, 0])
+    assert np.all(bc.fixed[:, 0, 1])
+    assert not np.any(bc.fixed[:, 1:])
+
+
+def test_invalid_edge():
+    bc = BoundaryConditions((2, 2))
+    with pytest.raises(ValueError, match="edge"):
+        bc.fix_edge("middle")
+
+
+def test_apply_point_load():
+    bc = BoundaryConditions((2, 2))
+    bc.apply_point_load(1, 1, 5.0)
+    assert bc.load[1, 1] == 5.0
+
+    bc2 = BoundaryConditions((2, 2), dof_dim=2)
+    bc2.apply_point_load(0, 0, (1.0, 2.0))
+    np.testing.assert_allclose(bc2.load[0, 0], [1.0, 2.0])
+
+    with pytest.raises(ValueError, match="size"):
+        bc2.apply_point_load(0, 0, (1.0,))
+
+
+def test_apply_uniform_load_on_edge():
+    bc = BoundaryConditions((3, 3))
+    bc.apply_uniform_load_on_edge("right", 2.0)
+    assert np.all(bc.load[-1] == 2.0)
+
+    bc2 = BoundaryConditions((3, 3), dof_dim=2)
+    bc2.apply_uniform_load_on_edge("left", (1.0, 0.0))
+    assert np.allclose(bc2.load[0], [1.0, 0.0])
+
+    with pytest.raises(ValueError, match="size"):
+        bc2.apply_uniform_load_on_edge("left", (1.0,))
+
+
+def test_integration_with_fea2d():
+    bc = BoundaryConditions((1, 1))
+    fem = FEA2D_T(bc.fixed)
+    x = np.ones(fem.shape)
+    fem.temperature(x, bc.load)
+
+    bc2 = BoundaryConditions((1, 1), dof_dim=2)
+    fem2 = FEA2D_K(bc2.fixed)
+    x2 = np.ones(fem2.shape)
+    fem2.displacement(x2, bc2.load)

--- a/tofea/__init__.py
+++ b/tofea/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 __all__ = [
     "DEFAULT_SOLVER",
     "__version__",
+    "boundary_conditions",
     "elements",
     "fea2d",
     "primitives",

--- a/tofea/boundary_conditions.py
+++ b/tofea/boundary_conditions.py
@@ -1,0 +1,94 @@
+"""Helper utilities for defining boundary conditions and loads."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ["BoundaryConditions"]
+
+
+def _edge_indices(edge: str) -> tuple:
+    match edge:
+        case "left":
+            return 0, slice(None)
+        case "right":
+            return -1, slice(None)
+        case "bottom":
+            return slice(None), 0
+        case "top":
+            return slice(None), -1
+        case _:
+            raise ValueError(f"Invalid edge name: {edge}")
+
+
+@dataclass
+class BoundaryConditions:
+    """Container for fixed degrees of freedom and loads.
+
+    Parameters
+    ----------
+    shape:
+        Number of elements in ``x`` and ``y`` direction.
+    dof_dim:
+        Degrees of freedom per node.
+
+    Examples
+    --------
+    >>> bc = BoundaryConditions((1, 1))
+    >>> bc.fix_edge("left")
+    >>> bool(bc.fixed[0, 0])
+    True
+    >>> bc.apply_point_load(1, 1, 2.0)
+    >>> float(bc.load[1, 1])
+    2.0
+    """
+
+    shape: tuple[int, int]
+    dof_dim: int = 1
+    fixed: NDArray[np.bool_] = field(init=False)
+    load: NDArray[np.float64] = field(init=False)
+
+    def __post_init__(self) -> None:
+        node_shape = (self.shape[0] + 1, self.shape[1] + 1)
+        if self.dof_dim == 1:
+            self.fixed = np.zeros(node_shape, dtype="?")
+            self.load = np.zeros(node_shape, dtype=float)
+        else:
+            self.fixed = np.zeros((*node_shape, self.dof_dim), dtype="?")
+            self.load = np.zeros((*node_shape, self.dof_dim), dtype=float)
+
+    def fix_edge(self, edge: str) -> None:
+        """Fix all nodes along an edge."""
+        idx = _edge_indices(edge)
+        if self.dof_dim == 1:
+            self.fixed[idx] = True
+        else:
+            self.fixed[(*idx, slice(None))] = True
+
+    def apply_point_load(
+        self, node_x: int, node_y: int, load_vector: float | Iterable[float]
+    ) -> None:
+        """Apply a load vector at a single node."""
+        if self.dof_dim == 1:
+            self.load[node_x, node_y] = float(cast(float, load_vector))
+        else:
+            vec = np.asarray(tuple(cast(Iterable[float], load_vector)), dtype=float)
+            if vec.size != self.dof_dim:
+                raise ValueError("load_vector has wrong size")
+            self.load[node_x, node_y] = vec
+
+    def apply_uniform_load_on_edge(self, edge: str, load_vector: float | Iterable[float]) -> None:
+        """Apply the same load to all nodes on an edge."""
+        idx = _edge_indices(edge)
+        if self.dof_dim == 1:
+            self.load[idx] = float(cast(float, load_vector))
+        else:
+            vec = np.asarray(tuple(cast(Iterable[float], load_vector)), dtype=float)
+            if vec.size != self.dof_dim:
+                raise ValueError("load_vector has wrong size")
+            self.load[(*idx, slice(None))] = vec


### PR DESCRIPTION
## Summary
- create `BoundaryConditions` helper with convenience methods
- expose module in `tofea.__init__`
- update heat conduction example to use the new helpers
- document the module in the API reference
- add comprehensive unit tests for boundary condition helpers
- improve type hints and extend tests for multi-DOF cases

## Testing
- `ruff check .`
- `pytest -q`
- `pre-commit run --files tofea/boundary_conditions.py tests/test_boundary_conditions.py`


------
https://chatgpt.com/codex/tasks/task_e_68572b5d6c90833280a0d3b0034526db

<!-- greptile_comment -->

## Greptile Summary

Introduces a new `BoundaryConditions` helper module that simplifies the definition of boundary conditions and loads in finite element analysis, replacing manual array manipulation with intuitive methods.

- Added `tofea/boundary_conditions.py` with helper methods for fixing edges and applying loads, including support for multi-DOF cases
- Updated `examples/heat_2d.py` to demonstrate practical usage of the new helper methods, improving code clarity
- Added comprehensive test suite in `tests/test_boundary_conditions.py` covering core functionality
- Added module documentation to `docs/reference.md` and exposed it through `tofea/__init__.py`
- Implementation includes proper type hints and docstrings throughout new code



<!-- /greptile_comment -->